### PR TITLE
pumgen with Simmetrix install

### DIFF
--- a/spack/README.rst
+++ b/spack/README.rst
@@ -326,7 +326,7 @@ Examples
   spack install seissol-utils+gmsh_gui+paraview+building_tools %gcc@8.3.0 ^parmetis+int64
 
   # 4. essential packages with simmetrix support for pumgen
-  spack install seissol-utils %gcc@8.3.0 ^pumgen+simmetrix_support ^parmetis+int64
+  spack install seissol-utils %gcc@8.3.0 ^pumgen+with_simmetrix ^parmetis+int64
 
 Usage
 ~~~~~

--- a/spack/packages/pumgen/package.py
+++ b/spack/packages/pumgen/package.py
@@ -25,6 +25,7 @@ class Pumgen(CMakePackage):
     depends_on('simmetrix-simmodsuite', when='+with_simmetrix')
     depends_on('pumi +int64 simmodsuite=kernels +zoltan ~fortran', when='+with_simmetrix')
     depends_on('zoltan@3.83 +parmetis+int64 ~fortran +shared')
+    depends_on('easi@1.2.0~asagi jit=impalajit,lua', when="+with_simmetrix")
 
     def cmake_args(self):
         args = [

--- a/spack/packages/pumi/package.py
+++ b/spack/packages/pumi/package.py
@@ -1,0 +1,128 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Pumi(CMakePackage):
+    """SCOREC RPI's Parallel Unstructured Mesh Infrastructure (PUMI).
+    An efficient distributed mesh data structure and methods to support
+    parallel adaptive analysis including general mesh-based operations,
+    such as mesh entity creation/deletion, adjacency and geometric
+    classification, iterators, arbitrary (field) data attachable to mesh
+    entities, efficient communication involving entities duplicated
+    across multiple tasks, migration of mesh entities between tasks,
+    and dynamic load balancing."""
+
+    homepage = "https://www.scorec.rpi.edu/pumi"
+    git = "https://github.com/SCOREC/core.git"
+
+    maintainers = ["cwsmith"]
+
+    tags = ["e4s"]
+
+    # We will use the scorec/core master branch as the 'nightly' version
+    # of pumi in spack.  The master branch is more stable than the
+    # scorec/core develop branch and we prefer not to expose spack users
+    # to the added instability.
+    version("master", submodules=True, branch="master")
+    version(
+        "2.2.7", submodules=True, commit="a295720d7b4828282484f2b78bac1f6504512de4"
+    )  # tag 2.2.7
+    version("2.2.6", commit="4dd330e960b1921ae0d8d4039b8de8680a20d993")  # tag 2.2.6
+    version("2.2.5", commit="73c16eae073b179e45ec625a5abe4915bc589af2")  # tag 2.2.5
+    version("2.2.4", commit="8072fdbafd53e0c9a63248a269f4cce5000a4a8e")  # tag 2.2.4
+    version("2.2.3", commit="d200cb366813695d0f18b514d8d8ecc382cb79fc")  # tag 2.2.3
+    version("2.2.2", commit="bc34e3f7cfd8ab314968510c71486b140223a68f")  # tag 2.2.2
+    version("2.2.1", commit="cd826205db21b8439026db1f6af61a8ed4a18564")  # tag 2.2.1
+    version("2.2.0", commit="8c7e6f13943893b2bc1ece15003e4869a0e9634f")  # tag 2.2.0
+    version("2.1.0", commit="840fbf6ec49a63aeaa3945f11ddb224f6055ac9f")
+
+    variant("int64", default=False, description="Enable 64bit mesh entity ids")
+    variant("shared", default=False, description="Build shared libraries")
+    variant("zoltan", default=False, description="Enable Zoltan Features")
+    variant("fortran", default=False, description="Enable FORTRAN interface")
+    variant("testing", default=False, description="Enable all tests")
+    variant(
+        "simmodsuite",
+        default="none",
+        values=("none", "base", "kernels", "full"),
+        description="Enable Simmetrix SimModSuite Support: 'base' enables "
+        "the minimum set of functionality, 'kernels' adds CAD kernel "
+        "support to 'base', and 'full' enables all functionality.",
+    )
+    variant(
+        "simmodsuite_version_check",
+        default=True,
+        description="Enable check of Simmetrix SimModSuite version. "
+        "Disable the check for testing new versions.",
+    )
+
+    depends_on("mpi")
+    depends_on("cmake@3:", type="build")
+    depends_on("zoltan", when="+zoltan")
+    depends_on("zoltan+int64", when="+zoltan+int64")
+    simbase = "+base"
+    simkernels = simbase + "+parasolid+acis+discrete"
+    simfull = (
+        simkernels
+        + "+abstract+adv+advmodel\
+                            +import+paralleladapt+parallelmesh"
+    )
+    depends_on("simmetrix-simmodsuite" + simbase, when="simmodsuite=base")
+    depends_on("simmetrix-simmodsuite" + simkernels, when="simmodsuite=kernels")
+    depends_on("simmetrix-simmodsuite" + simfull, when="simmodsuite=full")
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = [
+            "-DSCOREC_CXX_WARNINGS=OFF",
+            self.define_from_variant("ENABLE_ZOLTAN", "zoltan"),
+            "-DCMAKE_C_COMPILER=%s" % spec["mpi"].mpicc,
+            "-DCMAKE_CXX_COMPILER=%s" % spec["mpi"].mpicxx,
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            "-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc,
+            self.define_from_variant("PUMI_FORTRAN_INTERFACE", "fortran"),
+            "-DMDS_ID_TYPE=%s" % ("long" if "+int64" in spec else "int"),
+            "-DSKIP_SIMMETRIX_VERSION_CHECK=%s"
+            % ("ON" if "~simmodsuite_version_check" in spec else "OFF"),
+            self.define_from_variant("IS_TESTING", "testing"),
+            "-DMESHES=%s" % join_path(self.stage.source_path, "pumi-meshes"),
+        ]
+        if spec.satisfies("@2.2.3"):
+            args += ["-DCMAKE_CXX_STANDARD=11"]
+        if self.spec.satisfies("simmodsuite=base"):
+            args.append("-DENABLE_SIMMETRIX=ON")
+        if self.spec.satisfies("simmodsuite=kernels") or self.spec.satisfies("simmodsuite=full"):
+            args.append("-DENABLE_SIMMETRIX=ON")
+            args.append("-DSKIP_SIMMETRIX_VERSION_CHECK=ON")
+            args.append("-DSIM_DISCRETE=ON")
+            mpi_id = spec["mpi"].name + spec["mpi"].version.string[0]
+            args.append("-DSIM_MPI=" + mpi_id)
+        return args
+
+    def test(self):
+        if self.spec.version <= Version("2.2.6"):
+            return
+        exe = "uniform"
+        options = ["../testdata/pipe.dmg", "../testdata/pipe.smb", "pipe_unif.smb"]
+        expected = "mesh pipe_unif.smb written"
+        description = "testing pumi uniform mesh refinement"
+        self.run_test(exe, options, expected, purpose=description, work_dir=self.prefix.bin)
+
+        mpiexec = Executable(join_path(self.spec["mpi"].prefix.bin, "mpiexec")).command
+        mpiopt = ["-n", "2"]
+        exe = ["split"]
+        options = ["../testdata/pipe.dmg", "../testdata/pipe.smb", "pipe_2_.smb", "2"]
+        expected = "mesh pipe_2_.smb written"
+        description = "testing pumi mesh partitioning"
+        self.run_test(
+            mpiexec,
+            mpiopt + exe + options,
+            expected,
+            purpose=description,
+            work_dir=self.prefix.bin,
+        )


### PR DESCRIPTION
I've been able to install pumgen with simmetrix support on exception (the new server at LMU) with these changes.
Note that pumi differs with the package from spack only with the following changes: 
```diff
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -98,10 +98,9 @@ def cmake_args(self):
             args.append("-DENABLE_SIMMETRIX=ON")
         if self.spec.satisfies("simmodsuite=kernels") or self.spec.satisfies("simmodsuite=full"):
             args.append("-DENABLE_SIMMETRIX=ON")
-            args.append("-DSIM_PARASOLID=ON")
-            args.append("-DSIM_ACIS=ON")
+            args.append("-DSKIP_SIMMETRIX_VERSION_CHECK=ON")
             args.append("-DSIM_DISCRETE=ON")
-            mpi_id = spec["mpi"].name + spec["mpi"].version.string
+            mpi_id = spec["mpi"].name + spec["mpi"].version.string[0]
             args.append("-DSIM_MPI=" + mpi_id)
         return args
```
I've documented the workflow to compile at:
https://github.com/SeisSol/PUMGen/wiki/How-to-compile-PUMGen