### PR TITLE
harmonize hdf5, use simmodsuite=base and add SIMMETRIX_ROOT

### DIFF
--- a/spack/packages/pumgen/package.py
+++ b/spack/packages/pumgen/package.py
@@ -20,10 +20,10 @@ class Pumgen(CMakePackage):
     depends_on('mpi')
         
     depends_on('netcdf-c +shared +mpi', when='+with_netcdf') # NOTE: only tested with 4.4.0 version
-    depends_on('hdf5 +fortran +shared +hl +mpi') # NOTE: only tested with 1.8.21 version
+    depends_on('hdf5@1.10:1.12.2 +fortran +shared +threadsafe +mpi')
     depends_on('pumi +int64 +zoltan ~fortran', when='~with_simmetrix')
     depends_on('simmetrix-simmodsuite', when='+with_simmetrix')
-    depends_on('pumi +int64 simmodsuite=kernels +zoltan ~fortran ~simmodsuite_version_check', when='+with_simmetrix')
+    depends_on('pumi +int64 simmodsuite=base +zoltan ~fortran ~simmodsuite_version_check', when='+with_simmetrix')
     depends_on('zoltan@3.83 +parmetis+int64 ~fortran +shared')
     depends_on('easi@1.2: +asagi', when="+with_simmetrix")
 
@@ -36,7 +36,7 @@ class Pumgen(CMakePackage):
         if 'simmetrix-simmodsuite' in self.spec:
             mpi_id = self.spec["mpi"].name + self.spec["mpi"].version.up_to(1).string
             args.append("-DSIM_MPI=" + mpi_id)
-
+            args.append("-DSIMMETRIX_ROOT=" + self.spec["simmetrix-simmodsuite"].prefix)
         return args                                                                                                 
 
     def install(self, spec, prefix):


### PR DESCRIPTION
1. harmonize hdf5 version with the one specified in seissol-env.
2. use `simmodsuite=base`, made possible by https://github.com/spack/spack/pull/37401
3. adds DSIMMETRIX_ROOT  fixing the following issue:

```

1 error found in build log:
     26    -- Found PkgConfig: /import/exception-dump/ulrich/myLibs/spack-packages/linux-debian11-zen2/gcc-12.2.0/pkgconf-1.9.5-pdjoat6cd5pnjzwun7337putyjhqvno6/bin/pkg-config (found version "1.9.5")
     27    -- Checking for module 'asagi'
     28    --   Found asagi, version 1.0
     29    -- Checking for module 'netcdf'
     30    --   Found netcdf, version 4.7.4
     31    -- Configuring done (5.0s)
  >> 32    CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
     33    Please set them or make sure they are set and tested correctly in the CMake files:
     34    SIM_PS_KRNL_LIB
     35        linked by target "pumgen" in directory /tmp/ulrich/spack-stage/spack-stage-pumgen-gmsh4-e42b2kb5fxauozlva3s2u7gy4af447sf/spack-src
     36    
     37    -- Generating done (0.0s)
     38    CMake Warning:

See build log for details:
  /tmp/ulrich/spack-stage/spack-stage-pumgen-gmsh4-e42b2kb5fxauozlva3s2u7gy4af447sf/spack-build-out.txt
```
 