### PR TITLE
enforce jit=impalajit,lua for easi

### DIFF
--- a/spack/packages/seissol-env/package.py
+++ b/spack/packages/seissol-env/package.py
@@ -54,8 +54,8 @@ class SeissolEnv(BundlePackage):
     depends_on('asagi ~mpi ~mpi3 ~fortran', when="+asagi ~mpi")
     depends_on('asagi +mpi +mpi3', when="+asagi +mpi")
 
-    depends_on('easi@1.2 ~asagi', when="~asagi")
-    depends_on('easi@1.2 +asagi', when="+asagi")
+    depends_on('easi@1.2 ~asagi jit=impalajit,lua', when="~asagi")
+    depends_on('easi@1.2 +asagi jit=impalajit,lua', when="+asagi")
 
 
     depends_on('intel-mkl threads=none', when="extra_blas=mkl")


### PR DESCRIPTION
it turns out that easi not using the default variant is not a bug of spack, but due to the low priority of default variants in spack, see the answer here to the issue I opened: https://github.com/spack/spack/issues/41139
I therefore now fix the variant in seissol-env.