### PR TITLE
modification in cxx test to get spack working on NG2

### DIFF
--- a/spack/packages/cxxtest/package.py
+++ b/spack/packages/cxxtest/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
+from spack.package import *
 
 class Cxxtest(Package):
     """CxxTest is a unit testing framework for C++."""


### PR DESCRIPTION
I got an error saying that cxx test is not working on spack v1.1.0 without this change. 